### PR TITLE
S3 and other improvements

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -9,7 +9,7 @@
     "fuzz.settings.excavateWildcard.name" : "Excavate Wildcard",
     "fuzz.settings.excavateWildcard.hint" : "When Excavating tokens, if this option is enabled find the wildcard path. The Randomize Wildcard Images checkbox must be cheked before excavating",
     "fuzz.settings.useS3.name" : "Use S3 Bucket",
-    "fuzz.settings.useS3.hint" : "When enabled, the S3 bucket will be used instead of the user folder. This will require a valid AWS account and a valid S3 bucket name",
+    "fuzz.settings.useS3.hint" : "When enabled, the S3 bucket will be used as well as the user and core folders. This will require a valid AWS account and a valid S3 bucket name",
     "fuzz.settings.useS3name.name": "S3 Bucket Name",
     "fuzz.settings.useS3name.hint": "The name of the S3 bucket to use",
     "fuzz.settings.rebuildchash.name" : "Rebuild File Cache",

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,7 +1,5 @@
 class FilePickerDeepSearch {
   constructor(as = false) {
-    this._fileCache = [];
-    this._fileNameCache = [];
     this._fileIndexCache = {};
     this._searchCache = {};
     this.validExtensions = [
@@ -45,7 +43,7 @@ class FilePickerDeepSearch {
     this.s3 = game.settings.get("fuzzy-foundry", "useS3");
     this.s3name = game.settings.get("fuzzy-foundry", "useS3name");
     if (!as) this.buildAllCache();
-    this.fs = FuzzySearchFilters.FuzzySet(this._fileNameCache, true);
+    this.fs = FuzzySearchFilters.FuzzySet(Object.keys(this._fileIndexCache), true);
     this.fpPlus = game.modules.get("filepicker-plus")?.active;
   }
 
@@ -100,8 +98,8 @@ class FilePickerDeepSearch {
                 console.warn("Dig Down | Failed to save local cache. This is normal when indexing a very high amount of files, you might experience slower initialization.");
             }
       }
-      storedCache = this.unpackCache(storedCache);
-      console.log(this._fileCache.length + " files loaded from cache");
+      this.unpackCache(storedCache);
+      console.log(Object.values(this._fileIndexCache).flat().length + " files loaded from cache");
       return;
     }
     if (game.user.isGM) {
@@ -119,15 +117,13 @@ class FilePickerDeepSearch {
   unpackCache(json) {
     try{
       let cache = JSON.parse(this.de(json));
-      this._fileCache = cache._fileCache.filter((f) => !!f);
-      let fileNameCache = [];
+      let pathList = cache._fileCache.filter((f) => !!f);
       let fileIndexCache = {};
-      for (let file of this._fileCache) {
-        const fileName = file.split("/").pop();
-        fileNameCache.push(fileName);
-        fileIndexCache[fileName] = file;
+      for (let path of pathList) {
+        const fileName = path.split("/").pop();
+        fileIndexCache[fileName] ??= [];
+        fileIndexCache[fileName].push(path);
       }
-      this._fileNameCache = fileNameCache;
       this._fileIndexCache = fileIndexCache;
     } catch (e) {
       ui.notifications.error("Dig Down | New Caching System requires rebuild. Rebuilding Cache...");
@@ -144,14 +140,12 @@ class FilePickerDeepSearch {
     for (let directory of content.dirs) {
       await this.buildCache(isS3 ? directory : directory + "/", type);
     }
-    for (let file of content.files) {
-      const ff = file;
-      const ext = "." + ff.split(".").pop();
+    for (let path of content.files) {
+      const ext = "." + path.split(".").pop();
       if (!this.validExtensions.includes(ext)) continue;
-      const fileName = file.split("/").pop();
-      this._fileCache.push(file);
-      this._fileNameCache.push(fileName);
-      this._fileIndexCache[fileName] = file;
+      const fileName = path.split("/").pop();
+      this._fileIndexCache[fileName] ??= [];
+      this._fileIndexCache[fileName].push(path);
     }
   }
 
@@ -159,11 +153,10 @@ class FilePickerDeepSearch {
     if (typeof ForgeVTT !== "undefined" && ForgeVTT.usingTheForge) {
       const contents = await ForgeAPI.call("/assets");
 
-      for (let file of contents.assets) {
-        const fileName = file.name.split("/").pop();
-        this._fileCache.push(file.url);
-        this._fileNameCache.push(fileName);
-        this._fileIndexCache[fileName] = file.url;
+      for (let asset of contents.assets) {
+        const fileName = asset.name.split("/").pop();
+        this._fileIndexCache[fileName] ??= [];
+        this._fileIndexCache[fileName].push(asset.url);
       }
     } else {
       return;
@@ -176,7 +169,7 @@ class FilePickerDeepSearch {
 
   async saveCache() {
     const data = {
-      _fileCache: this._fileCache,
+      _fileCache: Object.values(this._fileIndexCache).flat(),
     };
     const string = this.en(JSON.stringify(data));
     try {
@@ -193,8 +186,10 @@ class FilePickerDeepSearch {
     await FilePicker.upload("data", "", file, {});
 
     //await game.settings.set("fuzzy-foundry", "fileCache", data);
-    ui.notifications.info(game.i18n.localize("fuzz.warn.done"));
-    console.log(`Saved ${this._fileCache.length} files to cache`);
+    ui.notifications.info(game.i18n.localize("fuzz.warn.done"), {
+      permanent: true,
+    });
+    console.log(`Saved ${data._fileCache.length} files to cache`);
   }
 
   static buildHtml(dmode, data) {
@@ -265,7 +260,7 @@ class FilePickerDeepSearch {
             .map((r) => r[1]) || []
         : [];
 
-      for (let fn of cache._fileNameCache) {
+      for (let fn in cache._fileIndexCache) {
         if (qresult.includes(fn)) continue;
         if (fn.toLowerCase().indexOf(queryLC) !== -1) {
           //if (fn.toLowerCase().includes(query.toLowerCase())) {
@@ -284,19 +279,21 @@ class FilePickerDeepSearch {
     cache._searchCache[query] = qresult;
     for (let file of qresult) {
       const ext = "." + file.split(".").pop();
-      if (!cache._fileIndexCache[file]?.startsWith(folder)) continue;
-      if (this.extensions && !this.extensions.includes(ext)) continue;
-      let olHtml = `<li style="position: relative;" class="file${
-        dmode == "thumbs" ? " flexrow" : ""
-      }" data-path="${cache._fileIndexCache[file]}" data-name="${
-        cache._fileIndexCache[file]
-      }" data-tooltip="${cache._fileIndexCache[file]}" draggable="true">`;
-      olHtml += FilePickerDeepSearch.buildHtml(dmode, {
-        fn: file,
-        fp: cache._fileIndexCache[file],
-      });
-      olHtml += `</li>`;  
-      $ol.append(olHtml);
+      const pathList = cache._fileIndexCache[file];
+      if (!pathList) continue;
+      for (const path of pathList) {
+        if (!path.startsWith(folder)) continue;
+        if (this.extensions && !this.extensions.includes(ext)) continue;
+        let olHtml = `<li style="position: relative;" class="file${
+          dmode == "thumbs" ? " flexrow" : ""
+        }" data-path="${path}" data-name="${path}" data-tooltip="${path}" draggable="true">`;
+        olHtml += FilePickerDeepSearch.buildHtml(dmode, {
+          fn: file,
+          fp: path,
+        });
+        olHtml += `</li>`;  
+        $ol.append(olHtml);
+      }
     }
     $("section.filepicker-body").append($ol);
     const _this = this;
@@ -372,20 +369,20 @@ class tokenExcavator {
       ".M4V",
     ];
     const cache = canvas.deepSearchCache;
-    const fs = FuzzySearchFilters.FuzzySet(cache._fileNameCache, true);
+    const fs = cache.fs;
     const queryRes = fs.get(query, []).filter((q) => {
       const ext = "." + q[1].split(".").pop();
       if (!validExt.includes(ext)) return false;
       if (exclude.length == 0) return true;
       for (let ex of exclude) {
-        if (cache._fileIndexCache[q[1]].includes(ex)) return true;
+        if (cache._fileIndexCache[q[1]][0].includes(ex)) return true;
       }
       return false;
     });
     if (!queryRes || queryRes.length === 0) return undefined;
-    if (!isWildcard || queryRes.length == 1) return cache._fileIndexCache[queryRes[0][1]];
+    if (!isWildcard || queryRes.length == 1) return cache._fileIndexCache[queryRes[0][1]][0];
     if (queryRes.length < 2) return undefined;
-    const path1 = cache._fileIndexCache[queryRes[0][1]];
+    const path1 = cache._fileIndexCache[queryRes[0][1]][0];
     const fileName1 = queryRes[0][1];
     const fileName2 = queryRes[1][1];
     const wildcard = tokenExcavator.makeWildcard(fileName1, fileName2);

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -42,9 +42,10 @@ class FilePickerDeepSearch {
     ];
     this.s3 = game.settings.get("fuzzy-foundry", "useS3");
     this.s3name = game.settings.get("fuzzy-foundry", "useS3name");
-    if (!as) this.buildAllCache();
-    this.fs = FuzzySearchFilters.FuzzySet(Object.keys(this._fileIndexCache), true);
     this.fpPlus = game.modules.get("filepicker-plus")?.active;
+    if (!as) this.buildAllCache().then(() => {
+      this.fs = FuzzySearchFilters.FuzzySet(Object.keys(this._fileIndexCache), true);
+    });
   }
 
   en(string) {

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -282,11 +282,13 @@ class FilePickerDeepSearch {
     const dmode = $(html).find(".display-mode.active")[0].dataset.mode;
     const queryLC = query.toLowerCase();
     let qresult = [];
-    let queryRes = [];
     if (!cache._searchCache[query]) {
+      qresult = Object.keys(cache._fileIndexCache).filter(fn => fn.toLowerCase().indexOf(queryLC) !== -1);
+      qresult.sort((a,b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+
       const fs = cache.fs;
-      queryRes = fs.get(query);
-      qresult = queryRes
+      const queryRes = fs.get(query);
+      const fuzzyResults = queryRes
         ? queryRes
             .filter((e) => {
               return e[0] > 0.3;
@@ -294,13 +296,13 @@ class FilePickerDeepSearch {
             .map((r) => r[1]) || []
         : [];
 
-      for (let fn in cache._fileIndexCache) {
+      fuzzyResults.sort((a,b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+
+      for (let fn of fuzzyResults) {
         if (qresult.includes(fn)) continue;
-        if (fn.toLowerCase().indexOf(queryLC) !== -1) {
-          //if (fn.toLowerCase().includes(query.toLowerCase())) {
-          qresult.push(fn);
-        }
+        qresult.push(fn);
       }
+
       if (qresult.length == 0) {
         return wrapped(event, query, rgx, html);
       }


### PR DESCRIPTION
This is mainly to fix issue #10, but I included a couple of other things too...

1. Corrected the description of the S3 setting
2. Removed `_fileCache` and `_fileNamecache` arrays.  There is now just the `_fileIndexCache` map.
3. `_fileIndexCache` now has an array as its value, so it will now cope with multiple files that have the same filename, but in different locations (previously, Dig Down would only show one file if there were multiple files with the same name).
4. Ensure the cache is built before initializing the fuzzy filter. `buildAllCache` is async, and you  were not waiting for it to complete before initializing the `FuzzySearchFilters`
5. Fixed filtering of deep search results when browsed into an S3 sub-drectory (Fixes #10)
6. Replace `%20` with space when displaying filenames.
7. Put substring results before fuzzy results, and sort them.

I appreciate this is quote a large PR, but it's split into multiple commits, so hopefully you should be able to see what's changed much easier.