### PR TITLE
Cache improvements

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -20,6 +20,6 @@
     "fuzz.settings.chatSearch.name" : "Chat Search",
     "fuzz.settings.chatSearch.hint" : "Enable search box on top of the chat sidebar",
     "fuzz.warn.cache": "Dig Down - Building File cache, please don't refresh, this can take some time...",
-    "fuzz.warn.done": "Dig Down - Building cache done. Please Refresh the page.",
+    "fuzz.warn.done": "Dig Down - Building cache done.",
     "fuzz.chat.search": "Search Chat Messages"
 }

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -7,6 +7,13 @@ Hooks.once("init", function () {
 });
 
 Hooks.once("init", function () {
+    function initializeDeepSearchCache() {
+        if (game.settings.get("fuzzy-foundry", "deepFile") && (game.user.isGM || game.settings.get("fuzzy-foundry", "deepFilePlayers")))
+            canvas.deepSearchCache = new FilePickerDeepSearch();
+        else
+            canvas.deepSearchCache = null;
+    }
+    
     game.settings.register("fuzzy-foundry", "deepFile", {
         name: game.i18n.localize("fuzz.settings.deepFile.name"),
         hint: game.i18n.localize("fuzz.settings.deepFile.hint"),
@@ -14,9 +21,7 @@ Hooks.once("init", function () {
         config: true,
         type: Boolean,
         default: true,
-        onChange: (sett) => {
-            if (sett) canvas.deepSearchCache = new FilePickerDeepSearch();
-        },
+        onChange: initializeDeepSearchCache
     });
 
     game.settings.register("fuzzy-foundry", "deepFilePlayers", {
@@ -88,9 +93,7 @@ Hooks.once("init", function () {
         config: true,
         type: Boolean,
         default: false,
-        onChange: (sett) => {
-            if (sett) canvas.deepSearchCache = new FilePickerDeepSearch();
-        },
+        onChange: initializeDeepSearchCache
     });
 
     game.settings.register("fuzzy-foundry", "useS3name", {
@@ -100,9 +103,7 @@ Hooks.once("init", function () {
         config: true,
         type: String,
         default: "",
-        onChange: (sett) => {
-            if (sett) canvas.deepSearchCache = new FilePickerDeepSearch();
-        },
+        onChange: initializeDeepSearchCache
     });
 
     game.settings.register("fuzzy-foundry", "localFileCache", {
@@ -113,9 +114,8 @@ Hooks.once("init", function () {
         type: String,
         default: "",
     });
-    Hooks.once("ready", () => { 
-        if (game.settings.get("fuzzy-foundry", "deepFile")) canvas.deepSearchCache = new FilePickerDeepSearch();
-    });
+
+    Hooks.once("ready", initializeDeepSearchCache);
 });
 
 Hooks.on("renderTokenConfig", (app, html) => {

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -176,7 +176,7 @@ Hooks.on("changeSidebarTab", (settings) => {
         e.preventDefault();
         $(e.currentTarget).prop("disabled", true).find("i").removeClass("fas fa-server").addClass("fas fa-spinner fa-spin");
         await FilePickerDeepSearch.wait(100);
-        canvas.deepSearchCache = await new FilePickerDeepSearch(true).buildAllCache(true);
+        canvas.deepSearchCache = new FilePickerDeepSearch(true);
         $(e.currentTarget).prop("disabled", false).find("i").removeClass("fas fa-spinner fa-spin").addClass("fas fa-server");
     });
 });

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -163,6 +163,12 @@ class FilePickerDeepSearch {
     let content = isS3
       ? await FilePicker.browse(type, dir, { bucket: this.s3name })
       : await FilePicker.browse(type, dir);
+
+    if (content.files.some(path => path.split("/").pop() == ".noscan")) {
+      console.log(`Dig Down | Skipping directory ${dir} due to .noscan file`);
+      return;
+    }
+
     for (let directory of content.dirs) {
       await this.buildCache(isS3 ? directory : directory + "/", type);
     }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -1,5 +1,5 @@
 class FilePickerDeepSearch {
-  constructor(as = false) {
+  constructor(force = false) {
     this._fileIndexCache = {};
     this._searchCache = {};
     this.validExtensions = [
@@ -44,7 +44,7 @@ class FilePickerDeepSearch {
     this.s3name = game.settings.get("fuzzy-foundry", "useS3name");
     this.fpPlus = game.modules.get("filepicker-plus")?.active;
     this.s3URLPrefix = undefined;
-    if (!as) this.buildAllCache().then(() => {
+    this.buildAllCache(force).then(() => {
       this.fs = FuzzySearchFilters.FuzzySet(Object.keys(this._fileIndexCache), true);
     });
   }

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -169,8 +169,9 @@ class FilePickerDeepSearch {
       return;
     }
 
+    let promises = [];
     for (let directory of content.dirs) {
-      await this.buildCache(isS3 ? directory : directory + "/", type);
+      promises.push(this.buildCache(isS3 ? directory : directory + "/", type));
     }
     for (let path of content.files) {
       const ext = "." + path.split(".").pop();
@@ -179,6 +180,11 @@ class FilePickerDeepSearch {
       this._fileIndexCache[fileName] ??= [];
       this._fileIndexCache[fileName].push(path);
     }
+
+    if (promises.length > 0)
+      return Promise.all(promises);
+    else
+      return
   }
 
   async buildForge() {


### PR DESCRIPTION
Various improvements to the cache...

1. Skip directories that contain a file called `.noscan`.  I have a large s3 repo, and don't want it to scan some of the dirs as it will massively bloat the cache and take up tons of memory.  I can prevent certain dirs from being scanned by creating this file.
2. Removed a couple of `await`s in `buildCache()`, and return a promise for those calls instead.  This halved the scan time for me.
3. Only load the cache if it is enabled for the current user.  This means that it won't load the cache for players if deep searching for players is disabled.
4. No longer needs a refresh after rebuilding the cache.

Each of these changes is a separate commit in this PR, so you can see the diffs for each change.